### PR TITLE
feat: Upgrade react-element-to-jsx-string to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@storybook/components": "^5.2.5",
     "copy-to-clipboard": "^3.0.8",
     "js-beautify": "^1.8.8",
-    "react-element-to-jsx-string": "14.3.1"
+    "react-element-to-jsx-string": "^14.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@storybook/components": "^5.2.5",
     "copy-to-clipboard": "^3.0.8",
     "js-beautify": "^1.8.8",
-    "react-element-to-jsx-string": "^14.0.3"
+    "react-element-to-jsx-string": "14.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,7 +1008,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@base2/pretty-print-object@^1.0.0":
+"@base2/pretty-print-object@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
@@ -8555,12 +8555,12 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-element-to-jsx-string@^14.0.3:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.1.0.tgz#31fcc3a82459d5e57ef852aa6879bcd0a578a8cb"
-  integrity sha512-uvfAsY6bn2c8HMBkxwj+2MMXcvNIkKDl0aZg2Jhzp+c096hZaXUNivVCP2H4RBtmGSSJcfMqQA5oPk8YdqFOVw==
+react-element-to-jsx-string@14.3.1:
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.1.tgz#a08fa6e46eb76061aca7eabc2e70f433583cb203"
+  integrity sha512-LRdQWRB+xcVPOL4PU4RYuTg6dUJ/FNmaQ8ls6w38YbzkbV6Yr5tFNESroub9GiSghtnMq8dQg2LcNN5aMIDzVg==
   dependencies:
-    "@base2/pretty-print-object" "^1.0.0"
+    "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.0"
 
 react-error-overlay@^6.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8555,7 +8555,7 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-element-to-jsx-string@14.3.1:
+react-element-to-jsx-string@^14.3.1:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.1.tgz#a08fa6e46eb76061aca7eabc2e70f433583cb203"
   integrity sha512-LRdQWRB+xcVPOL4PU4RYuTg6dUJ/FNmaQ8ls6w38YbzkbV6Yr5tFNESroub9GiSghtnMq8dQg2LcNN5aMIDzVg==


### PR DESCRIPTION
This update allows `filterProps` to be a function (`(val: any, key: string) => boolean`).
It also includes Typescript declaration file.

A filterProps function (`filterProps: (val) => val !== undefined`) allows to hide props
with defaultValue of `undefined`. Closes #96.