### PR TITLE
fix children bug

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,13 +50,13 @@ const renderJsx = (code: React.ReactElement, options: Required<JSXOptions>) => {
   let Type = renderedJSX.type;
 
   for (let i = 0; i < options.skip; i++) {
-    if (typeof code === 'undefined') {
+    if (typeof renderedJSX === 'undefined') {
       // eslint-disable-next-line no-console
       console.warn('Cannot skip undefined element');
       return;
     }
 
-    if (React.Children.count(code) > 1) {
+    if (React.Children.count(renderedJSX) > 1) {
       // eslint-disable-next-line no-console
       console.warn('Trying to skip an array of elements');
       return;


### PR DESCRIPTION
In the loop we need to look at renderedJSX instead of code
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.2.2-canary.103.336.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-addon-jsx@7.2.2-canary.103.336.0
  # or 
  yarn add storybook-addon-jsx@7.2.2-canary.103.336.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
