### PR TITLE
feat: disable jsx per story

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ storiesOf('test 2', module).addWithJSX(
 // <div>Inner HTML</div>
 ```
 
+### Disable JSX Addon
+
+If enabled globally, the JSX addon can be disabled on individual stories:
+
+```jsx
+export const Simple = () => <div>Hello</div>;
+
+Simple.story = {
+  parameters: {
+    jsx: {
+      disable: true
+    }
+  }
+};
+```
+
 ### Not JSX
 
 If a Vue story defines its view with a template string then it will be displayed

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -197,8 +197,6 @@ export const jsxDecorator = makeDecorator({
 
 export default {
   addWithJSX(this: StoryApi, kind: string, storyFn: StoryFn<any>) {
-    return this.add(kind, context =>
-      jsxDecorator(storyFn, context as StoryContext)
-    );
+    return this.add(kind, context => jsxDecorator(storyFn, context));
   }
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import {
   addons,
+  makeDecorator,
   StoryContext,
   StoryFn,
   StoryApi,
@@ -157,42 +158,47 @@ const defaultOpts = {
 };
 
 /** Extract components from story and emit them to the panel */
-export const jsxDecorator = (
-  storyFn: StoryFn<React.ReactElement<any>>,
-  parameters?: StoryContext
-) => {
-  const channel = addons.getChannel();
-  const story: ReturnType<typeof storyFn> & VueComponent = storyFn();
-  const options = {
-    ...defaultOpts,
-    ...((parameters && parameters.parameters.jsx) || {})
-  } as Required<JSXOptions>;
+export const jsxDecorator = makeDecorator({
+  name: 'jsx',
+  parameterName: 'jsx',
+  wrapper: (storyFn: any, parameters: StoryContext) => {
+    const story: ReturnType<typeof storyFn> & VueComponent = storyFn();
 
-  let components: ComponentMap = {};
-  let jsx = '';
+    const channel = addons.getChannel();
 
-  if (story.template) {
-    if (options.enableBeautify) {
-      jsx = beautifyHTML(story.template, options);
+    const options = {
+      ...defaultOpts,
+      ...((parameters && parameters.parameters.jsx) || {})
+    } as Required<JSXOptions>;
+
+    let components: ComponentMap = {};
+    let jsx = '';
+
+    if (story.template) {
+      if (options.enableBeautify) {
+        jsx = beautifyHTML(story.template, options);
+      } else {
+        jsx = story.template;
+      }
     } else {
-      jsx = story.template;
-    }
-  } else {
-    const rendered = renderJsx(story, options);
+      const rendered = renderJsx(story, options);
 
-    if (rendered) {
-      jsx = rendered;
-      components = getDocs(story);
+      if (rendered) {
+        jsx = rendered;
+        components = getDocs(story);
+      }
     }
+
+    channel.emit(EVENTS.ADD_JSX, (parameters || {}).id, jsx, components);
+
+    return story;
   }
-
-  channel.emit(EVENTS.ADD_JSX, (parameters || {}).id, jsx, components);
-
-  return story;
-};
+});
 
 export default {
   addWithJSX(this: StoryApi, kind: string, storyFn: StoryFn<any>) {
-    return this.add(kind, context => jsxDecorator(storyFn, context));
+    return this.add(kind, context =>
+      jsxDecorator(storyFn, context as StoryContext)
+    );
   }
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-jsx/issues/109

This adds the functionality to disable via CSF: 

```tsx
export const Simple = () => (
  <div>Hello</div>
);

Simple.story = {
  parameters: {
    jsx: {
      disable: true,
    },
  },
};
```

I tried to add an example to the `example` directory, but I'm struggling since these stories don't use CSF format